### PR TITLE
adds fix for bounty #548

### DIFF
--- a/app/assets/stylesheets/protip.css.scss
+++ b/app/assets/stylesheets/protip.css.scss
@@ -520,7 +520,9 @@ body.protip-single {
         }
         .comment {
           margin-bottom: 20px;
-
+          img {
+            max-width: 100%;
+          }
           p {
             font-size: 1.5em;
             line-height: 1.6em;


### PR DESCRIPTION
https://assembly.com/coderwall/bounties/548

added `img{max-width:100%}` to `.comment` to keep images from overflowing.
